### PR TITLE
update(deps): Bump upload-artifact to v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -92,7 +92,7 @@ runs:
 
     - name: Upload Scan Results Artifact
       if: success() || failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Fossology scan results
         path: results/


### PR DESCRIPTION
- upload-artifacts@v3 is deprecated now.